### PR TITLE
Change return for no caption data

### DIFF
--- a/classes/Caption.php
+++ b/classes/Caption.php
@@ -69,9 +69,9 @@ class Caption {
         // Get the caption data from the post meta
         $caption = get_post_meta( $id, '_' . CCFIC_KEY, true );
 
-        // If caption data is not present, return false
+        // If caption data is not present, return null
         if ( empty( $caption ) ) {
-            return false;
+            return;
         }
 
         // Legacy support: if caption is a string, convert it to an array

--- a/tests/test-caption.php
+++ b/tests/test-caption.php
@@ -167,7 +167,7 @@ class CaptionTest extends WP_UnitTestCase {
         // Get the output from the method
         $test = $this->caption->caption_data( $post->ID );
 
-        $this->assertFalse( $test );
+        $this->assertNull( $test );
     }
 
     /**


### PR DESCRIPTION
Change the return in the `caption_data()` method when no caption
data is present from `false` to `null`. This is in keeping with
the rest of the plugin's structure, as well as more clearly
indicating what is actually being indicated by the `return`.