### PR TITLE
Use `isset` to check for caption data

### DIFF
--- a/classes/RestApi.php
+++ b/classes/RestApi.php
@@ -59,9 +59,9 @@ class RestApi {
 
         // Assemble the caption data into an object
         $response = new \stdClass();
-        $response->caption_text = $data['caption_text'] ? $data['caption_text'] : false;
-        $response->source_text = $data['source_text'] ? $data['source_text'] : false;
-        $response->source_url = $data['source_url'] ? $data['source_url'] : false;
+        $response->caption_text = isset($data['caption_text']) ? $data['caption_text'] : false;
+        $response->source_text = isset($data['source_text']) ? $data['source_text'] : false;
+        $response->source_url = isset($data['source_url']) ? $data['source_url'] : false;
 
         return $response;
     }


### PR DESCRIPTION
PHP is throwing an `Undefined index` error for the 3 caption properties when there's no caption data. Using `isset` squelches it.