### PR TITLE
Fix WP REST API call

### DIFF
--- a/classes/RestApi.php
+++ b/classes/RestApi.php
@@ -20,7 +20,7 @@ class RestApi {
      */
     public function register_fields() {
         // Featured image caption data
-        register_api_field(
+        register_rest_field(
             'post',
             CCFIC_KEY,
             array(

--- a/featured-image-caption.php
+++ b/featured-image-caption.php
@@ -3,7 +3,7 @@
 Plugin Name: Featured Image Caption
 Plugin URI: https://christiaanconover.com/code/wp-featured-image-caption?utm_source=wp-featured-image-caption
 Description: Set a caption for the featured image of a post that can be displayed on your site.
-Version: 0.8.5
+Version: 0.8.6
 Author: Christiaan Conover
 Author URI: https://christiaanconover.com?utm_source=wp-featured-image-caption-author
 License: GPLv2.
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /* Define plugin constants */
 define( 'CCFIC_ID', 'ccfic' ); // Plugin ID
 define( 'CCFIC_NAME', 'Featured Image Caption' ); // Plugin name
-define( 'CCFIC_VERSION', '0.8.5' ); // Plugin version
+define( 'CCFIC_VERSION', '0.8.6' ); // Plugin version
 define( 'CCFIC_WPVER', '3.5' ); // Minimum required version of WordPress
 define( 'CCFIC_KEY', 'cc_featured_image_caption' ); // Database key (legacy support, ID now used)
 define( 'CCFIC_PATH', __FILE__ ) ; // Path to the primary plugin file

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: cconover
 Donate link: https://christiaanconover.com/code/wp-featured-image-caption?ref=plugin-readme
 Tags: image, caption, featured image, shortcode
 Requires at least: 3.5
-Tested up to: 4.5
-Stable tag: 0.8.5
+Tested up to: 4.7
+Stable tag: 0.8.6
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,6 +32,9 @@ Documentation is maintained on the plugin's [GitHub wiki](https://github.com/cco
 1. Featured Image Caption meta box below the Featured Image meta box.
 
 == Upgrade Notice ==
+
+= 0.8.6 =
+Fix an error thrown due to a deprecated function call for the WP REST API.
 
 = 0.8.5 =
 Fix an issue with empty caption data causing Undefined Index errors for the REST API.
@@ -100,6 +103,9 @@ Fixed check in theme function for whether a caption is set, and how the function
 Initial release.
 
 == Changelog ==
+
+= 0.8.6 =
+Fix an error thrown due to a deprecated function call for the WP REST API.
 
 = 0.8.5 =
 Fix an issue with [empty caption data causing `Undefined Index` errors for the REST API](https://github.com/cconover/featured-image-caption/pull/56).


### PR DESCRIPTION
Fix a bug caused by calling a deprecated WP REST API function. See #61 for details.