### PR TITLE
Require autoloader from current directory

### DIFF
--- a/featured-image-caption.php
+++ b/featured-image-caption.php
@@ -40,7 +40,7 @@ if ( is_admin() ) {
 function cc_featured_image_caption_loader()
 {
     // Composer autoloader
-    require_once 'vendor/autoload.php';
+    require_once __DIR__ . '/vendor/autoload.php';
 
     // Instantiate the plugin
     $bootstrap = new \cconover\FeaturedImageCaption\Bootstrap();


### PR DESCRIPTION
Fixes `Uncaught Error: Class 'cconover\FeaturedImageCaption\Bootstrap' not found`, since `include_path` doesn't always contain `.`.