### PR TITLE
Run validate on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,15 +36,6 @@ steps:
       - bash ./bin/install-wp-tests.sh $DB_NAME $DB_USER $DB_PASS $DB_HOSTNAME $WP_VERSION $SKIP_DB_CREATE
       - ./vendor/bin/phpunit
 
-  - name: github-release
-    image: plugins/github-release
-    settings:
-      api_key:
-        from_secret: github_access_token
-    when:
-      event:
-        - tag
-
   - name: publish
     image: alpine
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,8 +13,6 @@ steps:
       - pcre2grep -q "^Stable tag\:\s$CCFIC_VERSION$" readme.txt
       - pcre2grep -Mq "^==\s?Changelog\s?==\s*=\s?$CCFIC_VERSION\s?=$" readme.txt
     when:
-      branch:
-        - master
       event:
         - tag
 


### PR DESCRIPTION
Run the CI `validate` step only when tagging a release.